### PR TITLE
Travis config improved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,15 +45,13 @@ matrix:
           env:
             - TOXENV=packaging
             - PYPIUSER=grzanka
-            #  pypi secured password (PYPIPASS variable), you need to update it to your own if you want to use it
+            #  pypi secured password (PYPIPASS variable)
             - secure: "G5IIKLmPW//dxMYhNmum6yBLR8BzhrfIjFjMKy2ivKKkIO0wrrooMj3erzN2jqo9+P8bpWd2BsB900uatwXSWolB/aSAGLCqcpM16wYaE9JCcK/PKnHornKU0Ciig54+Lmk+/buikuomRYDdEOIA2okJMivAPTHbEefI2uGqB4cXE7OHBIkXuZ+pksZGkw3H7R9Vr2HII3IiN/91IyRYPSZTlzYW1RrDnDAQOnKyI6pctr6cFy0SKyjJyvW+0Et1jE1fzgX0JE/5zYBSmK7FNoq76NORY06jRvh7IrhJjZqi9VQyc02s73nlsneIhQvRFoYN82+xO9yIMIl9VDOYYrSQFSMO7G0/RMTVCWpCGW46MWNvP8wZ/+jbDUEy4A4YOdiZuO4EgTGigVwZo+9aG7vTQVu9vxTpiR1OojDYv5kClh0xevWW6vfxS2naH+YcqREShzB7qAOcuIm+zGe4bF3mD9h9XHnjTAL6gjpsFDO1dtqF2S/ol3Hw2nWDmT7Mh8bPv4wQZhWSCOzx7v5lZ8ZHb6gnlDHyN9gytIlIueypbQSmnjBYvmrsDju0gQwSOA5GBmv1Wm22bBFcuQ8Wb814LGiCaLNkLZ+yPK7QUaMp4iIMkRlkCEjQSXVspU17h5TsCG6afIUvJwMJFAk5ifgG23hO4OzIard5DcQ/uDo="
             - PYPITESTUSER=LeszekGrzanka
-            #  pypitest secured password (PYPITESTPASS variable), you need to update it to your own if you want to use it
+            #  pypitest secured password (PYPITESTPASS variable)
             - secure: "KLlzG+lbH+G0xs38rrqx6qIQjPZvrL+BPmw28MqryxS9JrjM7SRtsTyD13+6aQcbjVlOp9gqswQPKmbztWQqstOLnWu8AlpfIsadHLJ72Q67Ld2RP32KaRrNX2iMaebGxuPr8Zak+5+Gkq86mmeFTtPdPuNSV4+II+rmE/Q+jxAaqZ945XfvCHGPMMJuo2RHmN4ACuKjuB81VZx4LMLocsyHYH36hsPwzg+ECK1fbPMyd7ooRo4MkS8C6Mq2ZThCqP9i6XSyPnjxfLUWONkUvCXTdblG1Qe/pbO8quYjIWALXnvUsVDP8/6nQ/rm08AEkCG5Faf20/mTTBiI82V/TZvAjf0AwKKF1tXqjIaTAraVOih2xb046zJoqkwekNcZ6yAvPKXOZFdg34l/dxLWi8o2k25OcUbvhCvKHJI/d0wNBw2VowJx0GOrxisZYD3bgjdJlxw/1OGF24/Bj6JE9FpxkFQcNOx9J4UfwcmB2RDJMrXBlvcnIDJMsdyEzueDn4GsYNmZZfwnJUCAkUcO8e+1oQh5hGEiu8ICV/mZ84rmiBXoyiDPWfhf40quRnFDya4xudpK2YTRUJ8EoCCEXUPt8PFwvRd/dUpx3ldq3i/sCtkIytJvnyXeCUaGclgW+3PYfd0cmmqLWjS8Flkc6eOVdkGgq4Sak43OFYAeaWY="
-        - python: 3.4
-          env:
-           - TOXENV=cov
-           - secure: "UzByLKDLbYN9kU7UvIt/CmyHTBMVqMMR0XSj9J4KyXdW0wtFZU+ZG7pm5SoMcW/S/b2KoYINZrYqA7OGad+gc3EYlYfN2Y8+gI2bo9q+tHfxGojim2YqTxHsOS2I41QoxEtQF+5SW2p1HKj/tHz4x/U/lNGHRtdhcDmB8W3gWAnRnGXztk96hmdJzVxx5aY3/2x/p3Psgl2PI+DIpmhvi1EqKrN5+YLiNlGoNVesfbZL0os9iNwKWoo0xFqsIntUvfw1SFYTFQhorUxVtF8iVJKsWaFS4P7BJ8QSTcwG+WgNG2faBOfEcUoM5OIIIHN0rYRodL2DNgx5u+JWbBIP97hwMtets58c+3vKKHsoobxgwa6xSYdQHibkbcZn/LuifzmmyLpqFqWqQt8v83VLb6+cgOPqFAaHJlNs9eHTTaEJ7NSfB9U4XdEaCX1KfZBbCIj/3Kz5KlPp+Lt7TIDCD7DbKI1fStoy5VSBarj32ZRztIX/D5vNj4DgTMKfJfZV5bIdwXdoMgISIR+l/RlGWfcteXVb6/w2HC+m3eZWHdPpLeuHvlA/4VxXmAwpum2MOUcrZYNnuQPFGDEdh8KLQ4WExtLH7RySxO64UI59hEqOeTSM1A2/SaLwi/AxhUOAxw5DinimIm7zEn8ZjxoCz0mkg9TLOZ6gh2Frt1yCro4="
+            #  Code Climate secured token (CODECLIMATE_REPO_TOKEN variable)
+            - secure: "UzByLKDLbYN9kU7UvIt/CmyHTBMVqMMR0XSj9J4KyXdW0wtFZU+ZG7pm5SoMcW/S/b2KoYINZrYqA7OGad+gc3EYlYfN2Y8+gI2bo9q+tHfxGojim2YqTxHsOS2I41QoxEtQF+5SW2p1HKj/tHz4x/U/lNGHRtdhcDmB8W3gWAnRnGXztk96hmdJzVxx5aY3/2x/p3Psgl2PI+DIpmhvi1EqKrN5+YLiNlGoNVesfbZL0os9iNwKWoo0xFqsIntUvfw1SFYTFQhorUxVtF8iVJKsWaFS4P7BJ8QSTcwG+WgNG2faBOfEcUoM5OIIIHN0rYRodL2DNgx5u+JWbBIP97hwMtets58c+3vKKHsoobxgwa6xSYdQHibkbcZn/LuifzmmyLpqFqWqQt8v83VLb6+cgOPqFAaHJlNs9eHTTaEJ7NSfB9U4XdEaCX1KfZBbCIj/3Kz5KlPp+Lt7TIDCD7DbKI1fStoy5VSBarj32ZRztIX/D5vNj4DgTMKfJfZV5bIdwXdoMgISIR+l/RlGWfcteXVb6/w2HC+m3eZWHdPpLeuHvlA/4VxXmAwpum2MOUcrZYNnuQPFGDEdh8KLQ4WExtLH7RySxO64UI59hEqOeTSM1A2/SaLwi/AxhUOAxw5DinimIm7zEn8ZjxoCz0mkg9TLOZ6gh2Frt1yCro4="
         - os: osx
           language: generic
           env: TOXENV=py35
@@ -69,6 +67,11 @@ matrix:
         - os: osx
           language: generic
           env: TOXENV=py27
+#    uncomment and adjust if you want to allow some failures
+#    allow_failures:
+#        - os: osx
+#          language: generic
+#          env: TOXENV=py27
 
 # travis-ci runs by default on ancient Ubuntu 12.04 (precise)
 # following options will give us Ubuntu 14.04 (trusty)
@@ -92,6 +95,8 @@ script:
 after_success:
   # deploy to both servers: test and normal
   - if [[ $TRAVIS_PULL_REQUEST == "false" ]] && [[ $TRAVIS_OS_NAME == "linux" ]] && [[ $TOXENV == "packaging" ]]; then bash .travis/deploy_package.sh pypitest ; fi
+  # send coverage data
+  - if [[ $TRAVIS_PULL_REQUEST == "false" ]] && [[ $TRAVIS_OS_NAME == "linux" ]] && [[ $TOXENV == "packaging" ]]; then bash .travis/send_coverage.sh pypitest ; fi
   # deploy to normal if tag is present
   - if [[ $TRAVIS_TAG != "" ]] && [[ $TOXENV == "packaging" ]]; then bash .travis/deploy_package.sh pypi ; fi
 

--- a/.travis/install_linux.sh
+++ b/.travis/install_linux.sh
@@ -26,5 +26,3 @@ else
   pip install --upgrade versioneer
 fi
 pip install -r requirements.txt
-
-#versioneer install

--- a/.travis/send_coverage.sh
+++ b/.travis/send_coverage.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -x # Print command traces before executing command
+
+set -e # Exit immediately if a simple command exits with a non-zero status.
+
+set -o pipefail # Return value of a pipeline as the value of the last command to
+                # exit with a non-zero status, or zero if all commands in the
+                # pipeline exit successfully.
+
+pip install -rrequirements.txt
+pip install coverage
+pip install codeclimate-test-reporter
+pip install pytest-cov
+
+python -V
+py.test --cov
+
+set +x
+codeclimate-test-reporter
+set -x

--- a/README.rst
+++ b/README.rst
@@ -74,25 +74,29 @@ Beam Profile Analysing Tools
 
 Library provides methods to work with Beam Profiles which are sets of points
 (might be 2-D or 3-D also with extra metadata) sorted by one of coordinates.
-
+cd
 beprof is based on nparray class from numpy, and it provides
 numerous tools for different computations and data analysis.
 
 Installation
 ============
 
-Current version (0.1.0) is not available on PyPi, although once a
-stable version is ready it will be pushed to PyPi repo.
+Current version available on testing PyPi server, although once a
+stable version is ready it will be pushed to official PyPi repo.
+
+To install latest (unstable) version, type::
+
+    pip install -i https://testpypi.python.org/pypi beprof --user
 
 For now, installation can be done from this GIT repository, using::
 
-    ~$ pip install git+https://github.com/DataMedSci/beprof.git@master`
+    pip install git+https://github.com/DataMedSci/beprof.git@master`
 
 (where `@master` refers to the name of a branch)
 
 To unistall, simply use::
 
-    ~$ pip uninstall beprof
+    pip uninstall beprof
 
 Documentation
 =============

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,9 @@ environment:
       PYTHON: "C:\\Python27"
       TOX_ENV: "py27"
 
-    - platform: x64
-      PYTHON: "C:\\Python27-x64"
-      TOX_ENV: "py27"
+#    - platform: x64
+#      PYTHON: "C:\\Python27-x64"
+#      TOX_ENV: "py27"
 
 #  temporarily disabled as Appveyor seems to have broken config of Python 3.3
 #    - PYTHON: "C:\\Python33"
@@ -19,37 +19,37 @@ environment:
 #    - PYTHON: "C:\\Python33-x64"
 #      TOX_ENV: "py33"
 
-    - platform: x86
-      PYTHON: "C:\\Python34"
-      TOX_ENV: "py34"
-
-    - platform: x64
-      PYTHON: "C:\\Python34-x64"
-      TOX_ENV: "py34"
-
-    - platform: x86
-      PYTHON: "C:\\Python35"
-      TOX_ENV: "py35"
-
-    - platform: x64
-      PYTHON: "C:\\Python35-x64"
-      TOX_ENV: "py35"
-
-    - platform: x64
-      PYTHON: "C:\\Python34-x64"
-      TOX_ENV: "docs"
-
-    - platform: x64
-      PYTHON: "C:\\Python34-x64"
-      TOX_ENV: "packaging"
-
-    - platform: x64
-      PYTHON: "C:\\Python27-x64"
-      TOX_ENV: "py3pep8"
-
-    - platform: x64
-      PYTHON: "C:\\Python34-x64"
-      TOX_ENV: "pep8"
+#    - platform: x86
+#      PYTHON: "C:\\Python34"
+#      TOX_ENV: "py34"
+#
+#    - platform: x64
+#      PYTHON: "C:\\Python34-x64"
+#      TOX_ENV: "py34"
+#
+#    - platform: x86
+#      PYTHON: "C:\\Python35"
+#      TOX_ENV: "py35"
+#
+#    - platform: x64
+#      PYTHON: "C:\\Python35-x64"
+#      TOX_ENV: "py35"
+#
+#    - platform: x64
+#      PYTHON: "C:\\Python34-x64"
+#      TOX_ENV: "docs"
+#
+#    - platform: x64
+#      PYTHON: "C:\\Python34-x64"
+#      TOX_ENV: "packaging"
+#
+#    - platform: x64
+#      PYTHON: "C:\\Python27-x64"
+#      TOX_ENV: "py3pep8"
+#
+#    - platform: x64
+#      PYTHON: "C:\\Python34-x64"
+#      TOX_ENV: "pep8"
 
 # until we fix code of example project, lets allow failure here
 #matrix:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 import setuptools
-import sys
-import setuptools
 from pkg_resources import parse_version
 try:
     import versioneer

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs, packaging, pep8, py3pep8, py27, py33, py34, py35, cov
+envlist = docs, packaging, pep8, py3pep8, py27, py33, py34, py35
 
 [testenv]
 deps =
@@ -30,18 +30,6 @@ commands = flake8 .
 skip_install = True
 deps = flake8
 commands = flake8 .
-
-[testenv:cov]
-passenv = CODECLIMATE_REPO_TOKEN
-deps =
-    -rrequirements.txt
-    coverage
-    codeclimate-test-reporter
-    pytest-cov
-commands =
-    python -V
-    py.test --cov
-    codeclimate-test-reporter
 
 [flake8]
 exclude = .tox,*.egg,build,_vendor,data,versioneer.py,*_version.py,docs/conf.py


### PR DESCRIPTION
Removed cov target from tox and travis config  and replaced with a script which will be properly called (not on PR build).

Reduced appveyor config.

Cookiecutter template used: https://github.com/grzanka/cookiecutter-pip-docker-versioneer/releases/tag/v0.2.2.2
