### PR TITLE
Improved installation from git fails

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,7 @@ To install latest (unstable) version, type::
 
 For now, installation can be done from this GIT repository, using::
 
+    pip install versioneer
     pip install git+https://github.com/DataMedSci/beprof.git
 
 To unistall, simply use::

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,10 @@ def get_version():
         version += str(int(time.time()))
     return version
 
+def get_cmdclass():
+    import versioneer
+    return versioneer.get_cmdclass()
+
 try:
     # assume versioneer.py was generated using "versioneer install" command
     import versioneer
@@ -98,6 +102,5 @@ setuptools.setup(
         'numpy>=1.10.4',
         'scipy>=0.16.0',
     ],
-    cmdclass=versioneer.get_cmdclass(),
-
+    cmdclass=get_cmdclass()
 )

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,14 @@ def setup_versioneer():
             subprocess.check_output([exe_path, "install"])
 
 
+def clean_cache():
+    import importlib
+    importlib.invalidate_caches()
+
+
 def get_version():
     setup_versioneer()
+    clean_cache()
     import versioneer
     version = versioneer.get_version()
     parsed_version = parse_version(version)
@@ -61,6 +67,7 @@ def get_version():
 
 def get_cmdclass():
     setup_versioneer()
+    clean_cache()
     import versioneer
     return versioneer.get_cmdclass()
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def setup_versioneer():
         try:
             # call versioneer install to generate versioneer.py
             subprocess.check_output(["versioneer", "install"])
-        except IOError:
+        except OSError:
             # it looks versioneer is missing from $PATH
             # probably versioneer is installed in some user directory
 

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,58 @@
 import setuptools
 from pkg_resources import parse_version
+
+
+def pip_command_output(pip_args):
+    import sys
+    import pip
+    from io import StringIO
+    old_stdout = sys.stdout
+    sys.stdout = mystdout = StringIO()
+    pip.main(pip_args)
+    output = mystdout.getvalue()
+    mystdout.truncate(0)
+    sys.stdout = old_stdout
+    print("result", pip_args, len(output), output)
+    return output
+
+
 try:
+    # assume versioneer.py was generated using "versioneer install" command
     import versioneer
 except ImportError:
-    # dirty hack needed by readthedoc generation tool
+    # it looks versioneer.py is missing
+    # lets assume that versioneer package is installed
+    # and versioneer binary is present in $PATH
     import subprocess
-    subprocess.call(["versioneer", "install"])
-    import versioneer
+    try:
+        # call versioneer install to generate versioneer.py
+        subprocess.call(["versioneer", "install"])
+    except IOError:
+        # it looks versioneer is missing from $PATH
+        # probably versioneer is installed in some user directory
+
+        # query pip for list of files in versioneer package
+        output = pip_command_output(["show", "-f", "versioneer"])
+
+        # now we parse the results
+        main_path = [x[len("Location: "):] for x in output.split('\n')
+                     if x.startswith("Location")][0]
+        bin_path = [x[len("  "):] for x in output.split('\n')
+                    if x.endswith("/versioneer")][0]
+
+        # exe_path is absolute path to versioneer binary
+        import os
+        exe_path = os.path.join(main_path, bin_path)
+        # call versioneer install to generate versioneer.py
+        subprocess.call([exe_path, "install"])
+
+        import versioneer
 
 version = versioneer.get_version()
 parsed_version = parse_version(version)
 if '*@' in parsed_version[1]:
     import time
     version += str(int(time.time()))
-
 
 packages = ['beprof']
 
@@ -26,7 +65,7 @@ setuptools.setup(
     packages=packages,
     url='https://github.com/DataMedSci/beprof',
     license='GPL',
-    author=['Leszek Grzanka','Mateusz Krakowski', 'ant6'],
+    author=['Leszek Grzanka', 'Mateusz Krakowski', 'ant6'],
     author_email='grzanka@agh.edu.pl',
     description='Beam Profile Analysing Tools',
     long_description=readme + '\n',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,12 @@ def setup_versioneer():
 
 def clean_cache():
     import importlib
-    importlib.invalidate_caches()
+    try: # Python ver < 3.3
+      vermod = importlib.import_module("versioneer")
+      globals()["versioneer"] = vermod
+    except ImportError:
+      importlib.invalidate_caches()
+
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,15 @@ def pip_command_output(pip_args):
     return output
 
 
+def get_version():
+    import versioneer
+    version = versioneer.get_version()
+    parsed_version = parse_version(version)
+    if '*@' in parsed_version[1]:
+        import time
+        version += str(int(time.time()))
+    return version
+
 try:
     # assume versioneer.py was generated using "versioneer install" command
     import versioneer
@@ -46,13 +55,6 @@ except ImportError:
         # call versioneer install to generate versioneer.py
         subprocess.call([exe_path, "install"])
 
-        import versioneer
-
-version = versioneer.get_version()
-parsed_version = parse_version(version)
-if '*@' in parsed_version[1]:
-    import time
-    version += str(int(time.time()))
 
 packages = ['beprof']
 
@@ -61,7 +63,7 @@ with open('README.rst') as readme_file:
 
 setuptools.setup(
     name='beprof',
-    version=version,
+    version=get_version(),
     packages=packages,
     url='https://github.com/DataMedSci/beprof',
     license='GPL',

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,44 @@ def pip_command_output(pip_args):
     output = mystdout.getvalue()
     mystdout.truncate(0)
     sys.stdout = old_stdout
-    print("result", pip_args, len(output), output)
     return output
 
 
+def setup_versioneer():
+    try:
+        # assume versioneer.py was generated using "versioneer install" command
+        import versioneer
+        versioneer.get_version()
+    except ImportError:
+        # it looks versioneer.py is missing
+        # lets assume that versioneer package is installed
+        # and versioneer binary is present in $PATH
+        import subprocess
+        try:
+            # call versioneer install to generate versioneer.py
+            subprocess.check_output(["versioneer", "install"])
+        except IOError:
+            # it looks versioneer is missing from $PATH
+            # probably versioneer is installed in some user directory
+
+            # query pip for list of files in versioneer package
+            output = pip_command_output(["show", "-f", "versioneer"])
+
+            # now we parse the results
+            main_path = [x[len("Location: "):] for x in output.split('\n')
+                         if x.startswith("Location")][0]
+            bin_path = [x[len("  "):] for x in output.split('\n')
+                        if x.endswith("/versioneer")][0]
+
+            # exe_path is absolute path to versioneer binary
+            import os
+            exe_path = os.path.join(main_path, bin_path)
+            # call versioneer install to generate versioneer.py
+            subprocess.check_output([exe_path, "install"])
+
+
 def get_version():
+    setup_versioneer()
     import versioneer
     version = versioneer.get_version()
     parsed_version = parse_version(version)
@@ -25,42 +58,12 @@ def get_version():
         version += str(int(time.time()))
     return version
 
+
 def get_cmdclass():
+    setup_versioneer()
     import versioneer
     return versioneer.get_cmdclass()
 
-try:
-    # assume versioneer.py was generated using "versioneer install" command
-    import versioneer
-except ImportError:
-    # it looks versioneer.py is missing
-    # lets assume that versioneer package is installed
-    # and versioneer binary is present in $PATH
-    import subprocess
-    try:
-        # call versioneer install to generate versioneer.py
-        subprocess.call(["versioneer", "install"])
-    except IOError:
-        # it looks versioneer is missing from $PATH
-        # probably versioneer is installed in some user directory
-
-        # query pip for list of files in versioneer package
-        output = pip_command_output(["show", "-f", "versioneer"])
-
-        # now we parse the results
-        main_path = [x[len("Location: "):] for x in output.split('\n')
-                     if x.startswith("Location")][0]
-        bin_path = [x[len("  "):] for x in output.split('\n')
-                    if x.endswith("/versioneer")][0]
-
-        # exe_path is absolute path to versioneer binary
-        import os
-        exe_path = os.path.join(main_path, bin_path)
-        # call versioneer install to generate versioneer.py
-        subprocess.call([exe_path, "install"])
-
-
-packages = ['beprof']
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
@@ -68,7 +71,7 @@ with open('README.rst') as readme_file:
 setuptools.setup(
     name='beprof',
     version=get_version(),
-    packages=packages,
+    packages=['beprof'],
     url='https://github.com/DataMedSci/beprof',
     license='GPL',
     author=['Leszek Grzanka', 'Mateusz Krakowski', 'ant6'],


### PR DESCRIPTION
Introduces many nasty hacks, but installation from GIT works, without need to commit versioneer.py and _version.py files to the repo.

Closes #42 
