### PR TITLE
Feature/82 wercker config

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,7 +1,17 @@
 command-timeout: 60
 
 build:
-  # test python 2.7 as default
+  # will probably build here, now just echo
+  box: python:slim
+  steps:
+    - script:
+        name: echo python information
+        code: |
+          echo "python version $(python --version) running"
+          echo "pip version $(pip --version) running"
+
+
+test-python27:
   box: python:2.7
   steps:
     # installing necessary requirements
@@ -20,10 +30,8 @@ build:
         name: run pytest
         code: python -m pytest
 
-python32:
+test-python32:
   box: python:3.2
-
-  # make a source package in standard python box
   steps:
     # installing necessary requirements
     - pip-install:
@@ -42,7 +50,7 @@ python32:
         name: run pytest
         code: python -m pytest
 
-python33:
+test-python33:
   box: python:3.3
 
   # make a source package in standard python box
@@ -64,10 +72,8 @@ python33:
         name: run pytest
         code: python -m pytest
 
-python34:
+test-python34:
   box: python:3.4
-
-  # make a source package in standard python box
   steps:
     # installing necessary requirements
     - pip-install:
@@ -86,10 +92,8 @@ python34:
         name: run pytest
         code: python -m pytest
 
-python35:
+test-python35:
   box: python:3.5
-
-  # make a source package in standard python box
   steps:
     # installing necessary requirements
     - pip-install:

--- a/wercker.yml
+++ b/wercker.yml
@@ -41,3 +41,69 @@ python32:
     - script:
         name: run pytest
         code: python -m pytest
+
+python33:
+  box: python:3.3
+
+  # make a source package in standard python box
+  steps:
+    # installing necessary requirements
+    - pip-install:
+        requirements_file: "requirements.txt"
+        extra_args: "-rtests/requirements-test.txt"
+        packages_list: "wheel"
+
+    # checking python version
+    - script:
+        name: echo python information
+        code: |
+          echo "python version $(python --version) running"
+          echo "pip version $(pip --version) running"
+
+    - script:
+        name: run pytest
+        code: python -m pytest
+
+python34:
+  box: python:3.4
+
+  # make a source package in standard python box
+  steps:
+    # installing necessary requirements
+    - pip-install:
+        requirements_file: "requirements.txt"
+        extra_args: "-rtests/requirements-test.txt"
+        packages_list: "wheel"
+
+    # checking python version
+    - script:
+        name: echo python information
+        code: |
+          echo "python version $(python --version) running"
+          echo "pip version $(pip --version) running"
+
+    - script:
+        name: run pytest
+        code: python -m pytest
+
+python35:
+  box: python:3.5
+
+  # make a source package in standard python box
+  steps:
+    # installing necessary requirements
+    - pip-install:
+        requirements_file: "requirements.txt"
+        extra_args: "-rtests/requirements-test.txt"
+        packages_list: "wheel"
+
+    # checking python version
+    - script:
+        name: echo python information
+        code: |
+          echo "python version $(python --version) running"
+          echo "pip version $(pip --version) running"
+
+    - script:
+        name: run pytest
+        code: python -m pytest

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-#test-python-2.7
+#test python 2.7 as default
 box: python:2.7
 
 command-timeout: 60
@@ -22,7 +22,7 @@ build:
         code: python -m pytest
 
 
-test-python-3.2:
+test_python_32:
   box: python:3.2
 
   command-timeout: 60

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,48 +1,48 @@
-# test on python 2.7
-box: python:2.7
+test-python-2.7:
+  box: python:2.7
 
-command-timeout: 60
+  command-timeout: 60
 
-build:
-  steps:
-    # installing necessary requirements
-    - pip-install:
-        requirements_file: "requirements.txt"
-        extra_args: "-rtests/requirements-test.txt"
-        packages_list: "pytest"
+  build:
+    steps:
+      # installing necessary requirements
+      - pip-install:
+          requirements_file: "requirements.txt"
+          extra_args: "-rtests/requirements-test.txt"
+          packages_list: "pytest"
 
-    - script:
-        name: echo python information
-        code: |
-          echo "python version $(python --version) running"
-          echo "pip version $(pip --version) running"
+      - script:
+          name: echo python information
+          code: |
+            echo "python version $(python --version) running"
+            echo "pip version $(pip --version) running"
 
-    - script:
-        name: run pytest
-        code: python -m pytest
+      - script:
+          name: run pytest
+          code: python -m pytest
 
 
-# test on python 3.2
-box: python:3.2
+test-python-3.2:
+  box: python:3.2
 
-command-timeout: 60
+  command-timeout: 60
 
-# make a source package in standard python box
-build:
-  steps:
-    # installing necessary requirements
-    - pip-install:
-        requirements_file: "requirements.txt"
-        extra_args: "-rtests/requirements-test.txt"
-        packages_list: "wheel"
+  # make a source package in standard python box
+  build:
+    steps:
+      # installing necessary requirements
+      - pip-install:
+          requirements_file: "requirements.txt"
+          extra_args: "-rtests/requirements-test.txt"
+          packages_list: "wheel"
 
-    # checking python version
-    - script:
-        name: echo python information
-        code: |
-          echo "python version $(python --version) running"
-          echo "pip version $(pip --version) running"
+      # checking python version
+      - script:
+          name: echo python information
+          code: |
+            echo "python version $(python --version) running"
+            echo "pip version $(pip --version) running"
 
-    - script:
-        name: run pytest
-        code: python -m pytest
+      - script:
+          name: run pytest
+          code: python -m pytest

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,49 +1,43 @@
+command-timeout: 60
+
 build:
-  #test python 2.7 as default
+  # test python 2.7 as default
   box: python:2.7
+  steps:
+    # installing necessary requirements
+    - pip-install:
+        requirements_file: "requirements.txt"
+        extra_args: "-rtests/requirements-test.txt"
+        packages_list: "pytest"
 
-  command-timeout: 60
+    - script:
+        name: echo python information
+        code: |
+          echo "python version $(python --version) running"
+          echo "pip version $(pip --version) running"
 
-  build:
-    steps:
-      # installing necessary requirements
-      - pip-install:
-          requirements_file: "requirements.txt"
-          extra_args: "-rtests/requirements-test.txt"
-          packages_list: "pytest"
-
-      - script:
-          name: echo python information
-          code: |
-            echo "python version $(python --version) running"
-            echo "pip version $(pip --version) running"
-
-      - script:
-          name: run pytest
-          code: python -m pytest
-
+    - script:
+        name: run pytest
+        code: python -m pytest
 
 python32:
   box: python:3.2
 
-  command-timeout: 60
-
   # make a source package in standard python box
-  build:
-    steps:
-      # installing necessary requirements
-      - pip-install:
-          requirements_file: "requirements.txt"
-          extra_args: "-rtests/requirements-test.txt"
-          packages_list: "wheel"
+  steps:
+    # installing necessary requirements
+    - pip-install:
+        requirements_file: "requirements.txt"
+        extra_args: "-rtests/requirements-test.txt"
+        packages_list: "wheel"
 
-      # checking python version
-      - script:
-          name: echo python information
-          code: |
-            echo "python version $(python --version) running"
-            echo "pip version $(pip --version) running"
+    # checking python version
+    - script:
+        name: echo python information
+        code: |
+          echo "python version $(python --version) running"
+          echo "pip version $(pip --version) running"
 
-      - script:
-          name: run pytest
-          code: python -m pytest
+    - script:
+        name: run pytest
+        code: python -m pytest

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,28 +1,29 @@
-#test python 2.7 as default
-box: python:2.7
-
-command-timeout: 60
-
 build:
-  steps:
-    # installing necessary requirements
-    - pip-install:
-        requirements_file: "requirements.txt"
-        extra_args: "-rtests/requirements-test.txt"
-        packages_list: "pytest"
+  #test python 2.7 as default
+  box: python:2.7
 
-    - script:
-        name: echo python information
-        code: |
-          echo "python version $(python --version) running"
-          echo "pip version $(pip --version) running"
+  command-timeout: 60
 
-    - script:
-        name: run pytest
-        code: python -m pytest
+  build:
+    steps:
+      # installing necessary requirements
+      - pip-install:
+          requirements_file: "requirements.txt"
+          extra_args: "-rtests/requirements-test.txt"
+          packages_list: "pytest"
+
+      - script:
+          name: echo python information
+          code: |
+            echo "python version $(python --version) running"
+            echo "pip version $(pip --version) running"
+
+      - script:
+          name: run pytest
+          code: python -m pytest
 
 
-test_python_32:
+python32:
   box: python:3.2
 
   command-timeout: 60

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,50 +1,42 @@
-# This references the default Python container from
-# the Docker Hub with the 2.7 tag:
-# https://registry.hub.docker.com/_/python/
-# If you want to use a slim Python container with
-# version 3.4.3 you would use: python:3.4-slim
-# If you want Google's container you would reference google/python
-# Read more about containers on our dev center
-# http://devcenter.wercker.com/docs/containers/index.html
+# test on python 2.7
 box: python:2.7
-# You can also use services such as databases. Read more on our dev center:
-# http://devcenter.wercker.com/docs/services/index.html
-# services:
-    # - postgres
-    # http://devcenter.wercker.com/docs/services/postgresql.html
 
-    # - mongo
-    # http://devcenter.wercker.com/docs/services/mongodb.html
+command-timeout: 60
 
-# This is the build pipeline. Pipelines are the core of wercker
-# Read more about pipelines on our dev center
-# http://devcenter.wercker.com/docs/pipelines/index.html
 build:
-  # The steps that will be executed on build
-  # Steps make up the actions in your pipeline
-  # Read more about steps on our dev center:
-  # http://devcenter.wercker.com/docs/steps/index.html
   steps:
-    # A step that sets up the python virtual environment
-#    - virtualenv:
-#        name: setup virtual environment
-#        install_wheel: false # Enable wheel to speed up builds (experimental)
-
-    # # Use this virtualenv step for python 3.2
-    # - virtualenv
-    #     name: setup virtual environment
-    #     python_location: /usr/bin/python3.2
-
-    # A step that executes `pip install` command.
+    # installing necessary requirements
     - pip-install:
+        requirements_file: "requirements.txt"
+        extra_args: "-rtests/requirements-test.txt"
         packages_list: "pytest"
 
-    # # This pip-install clears the local wheel cache
-    # - pip-install:
-    #     clean_wheel_dir: true
+    - script:
+        name: echo python information
+        code: |
+          echo "python version $(python --version) running"
+          echo "pip version $(pip --version) running"
 
-    # A custom script step, name value is used in the UI
-    # and the code value contains the command that get executed
+    - script:
+        name: run pytest
+        code: python -m pytest
+
+
+# test on python 3.2
+box: python:3.2
+
+command-timeout: 60
+
+# make a source package in standard python box
+build:
+  steps:
+    # installing necessary requirements
+    - pip-install:
+        requirements_file: "requirements.txt"
+        extra_args: "-rtests/requirements-test.txt"
+        packages_list: "wheel"
+
+    # checking python version
     - script:
         name: echo python information
         code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,16 +1,3 @@
-command-timeout: 60
-
-build:
-  # will probably build here, now just echo
-  box: python:slim
-  steps:
-    - script:
-        name: echo python information
-        code: |
-          echo "python version $(python --version) running"
-          echo "pip version $(pip --version) running"
-
-
 test-python27:
   box: python:2.7
   steps:

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,25 +1,25 @@
-test-python-2.7:
-  box: python:2.7
+#test-python-2.7
+box: python:2.7
 
-  command-timeout: 60
+command-timeout: 60
 
-  build:
-    steps:
-      # installing necessary requirements
-      - pip-install:
-          requirements_file: "requirements.txt"
-          extra_args: "-rtests/requirements-test.txt"
-          packages_list: "pytest"
+build:
+  steps:
+    # installing necessary requirements
+    - pip-install:
+        requirements_file: "requirements.txt"
+        extra_args: "-rtests/requirements-test.txt"
+        packages_list: "pytest"
 
-      - script:
-          name: echo python information
-          code: |
-            echo "python version $(python --version) running"
-            echo "pip version $(pip --version) running"
+    - script:
+        name: echo python information
+        code: |
+          echo "python version $(python --version) running"
+          echo "pip version $(pip --version) running"
 
-      - script:
-          name: run pytest
-          code: python -m pytest
+    - script:
+        name: run pytest
+        code: python -m pytest
 
 
 test-python-3.2:


### PR DESCRIPTION
Simple build set for wercker: after pipeline *build* which for now only prints python version, the following pipelines are executed:
- test-python27 
- test-python32
- test-python33
- test-python34
- test-python35

Each one is a separate box with different Python and executes pytest. We could add building wheels etc. and testing on them later, but I just need testing all Python versions.